### PR TITLE
Update GitHub workflow. Remove GAR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,13 +54,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
         run: ./gradlew build --stacktrace ${{ steps.build_variables.outputs.REPO }}-web:installDist
-      - name: Login to GAR
-        uses: docker/login-action@v1
-        # use service account flow defined at: https://github.com/docker/login-action#service-account-based-authentication-1
-        with:
-          registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
       - name: Build and publish slim container image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
GAR (Google Artifact Registry) is not used. Instead, Docker Hub and GitHub packages are used